### PR TITLE
fix prettier vscode plugin does not work

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -3,6 +3,13 @@ const prefix = "/*" + magic;
 const postfix = magic + "*/";
 
 export async function preProcess(code) {
+  globalThis.WebAssembly.instantiateStreaming =
+    globalThis.WebAssembly.instantiateStreaming ??
+    (async (source, importObject) => {
+      const response = await Promise.resolve(source);
+      const buffer = await response.arrayBuffer();
+      return WebAssembly.instantiate(buffer, importObject);
+    });
   const assemblyscript = await import("assemblyscript");
   const NodeKind = assemblyscript.NodeKind;
   const visitDecorators = (node) => {


### PR DESCRIPTION
In vscode prettier plugin environment, instantiateStreaming does not exist. this patch add a polyfill 
fix https://github.com/prettier/prettier-vscode/issues/3907